### PR TITLE
@ Prefix enhancement  proposal by Summerclaw

### DIFF
--- a/lsl/OpenCollar - anim.lsl
+++ b/lsl/OpenCollar - anim.lsl
@@ -767,6 +767,9 @@ default
                     {
                         Notify(kAv, "Attempting to trigger the AO menu.  This will only work if " + llKey2Name(g_kWearer) + " is wearing the OpenCollar Sub AO.", FALSE);
                         AOMenu(kAv, iAuth);
+
+                        llWhisper(g_iInterfaceChannel, "CollarCommand|" + (string)iAuth + "|" + AO_MENU + "|" + (string)kAv);
+                        llWhisper(g_iAOChannel, AO_MENU + "|" + (string)kAv);
                         //llSay(g_iInterfaceChannel, AO_MENU + "|" + (string)kID);
                         //                llMessageLinked(LINK_SET, COMMAND_NOAUTH, "triggerao", kID);
                     }

--- a/lsl/OpenCollar - auth.lsl
+++ b/lsl/OpenCollar - auth.lsl
@@ -40,6 +40,8 @@ integer COMMAND_WEARER = 503;
 integer COMMAND_EVERYONE = 504;
 integer COMMAND_RLV_RELAY = 507;
 integer COMMAND_SAFEWORD = 510;  // new for safeword
+// equal to COMMAND_NOAUTH if chat command with @ sent by non-owner
+integer COMMAND_AUTH_IF_OWNER = 511;  
 integer COMMAND_BLACKLIST = 520;
 // added so when the sub is locked out they can use postions
 integer COMMAND_WEARERLOCKEDOUT = 521;
@@ -785,19 +787,14 @@ default
 
     link_message(integer iSender, integer iNum, string sStr, key kID)
     {  //authenticate messages on COMMAND_NOAUTH
-        if (iNum == COMMAND_NOAUTH)
+        if ((iNum == COMMAND_NOAUTH) || (iNum == COMMAND_AUTH_IF_OWNER))
         {
             integer iAuth = Auth((string)kID, FALSE);
+            
             // for @ support
-            if ((llGetSubString(sStr, 0, 0) == "@"))
-            {
-                if((iAuth==COMMAND_EVERYONE)||(iAuth==COMMAND_GROUP))
-                    return;
-                else
-                {
-                    sStr = llGetSubString(sStr, 1, -1);
-                }
-            }
+            if (iNum == COMMAND_AUTH_IF_OWNER)
+                if((iAuth == COMMAND_EVERYONE) || (iAuth==COMMAND_GROUP))
+                    return; 
 
             if ((iNum == COMMAND_OWNER || kID == g_kWearer) && (sStr=="reset"))
             {

--- a/lsl/OpenCollar - auth.lsl
+++ b/lsl/OpenCollar - auth.lsl
@@ -788,6 +788,17 @@ default
         if (iNum == COMMAND_NOAUTH)
         {
             integer iAuth = Auth((string)kID, FALSE);
+            // for @ support
+            if ((llGetSubString(sStr, 0, 0) == "@"))
+            {
+                if((iAuth==COMMAND_EVERYONE)||(iAuth==COMMAND_GROUP))
+                    return;
+                else
+                {
+                    sStr = llGetSubString(sStr, 1, -1);
+                }
+            }
+
             if ((iNum == COMMAND_OWNER || kID == g_kWearer) && (sStr=="reset"))
             {
                 Notify(kID, "The command 'reset' is deprecated. Please use 'runaway' to leave the owner and clear all settings or 'resetscripts' to only reset the script in the collar.", FALSE);

--- a/lsl/OpenCollar - listener.lsl
+++ b/lsl/OpenCollar - listener.lsl
@@ -24,6 +24,8 @@ integer COMMAND_WEARER = 503;
 integer COMMAND_EVERYONE = 504;
 integer COMMAND_RLV_RELAY = 507;
 integer COMMAND_SAFEWORD = 510;  // new for safeword
+// equal to COMMAND_NOAUTH if chat command with @ sent by non-owner
+integer COMMAND_AUTH_IF_OWNER = 511;
 //integer SEND_IM = 1000; deprecated.  each script should send its own IMs now.  This is to reduce even the tiny bt of lag caused by having IM slave scripts
 integer POPUP_HELP = 1001;
 
@@ -304,8 +306,8 @@ default
                 // added @ prefix for all owned subs and yourself
                 else if (cSign == "@")
                 {
-                    // not removing sign, so Auth module will know to try change auth level
-                    llMessageLinked(LINK_SET, COMMAND_NOAUTH, sMsg, kID);
+                    sMsg = llGetSubString(sMsg, 1, -1);
+                    llMessageLinked(LINK_SET, COMMAND_AUTH_IF_OWNER, sMsg, kID);
                 }
             }
         }

--- a/lsl/OpenCollar - listener.lsl
+++ b/lsl/OpenCollar - listener.lsl
@@ -280,23 +280,33 @@ default
 
         }
         else
-        { //check for our prefix, or *
+        {   //check for our prefix, or *
             if (StartsWith(sMsg, g_sPrefix))
             {
                 //trim
                 sMsg = llGetSubString(sMsg, llStringLength(g_sPrefix), -1);
                 llMessageLinked(LINK_SET, COMMAND_NOAUTH, sMsg, kID);
             }
-            else if (llGetSubString(sMsg, 0, 0) == "*")
+            else 
             {
-                sMsg = llGetSubString(sMsg, 1, -1);
-                llMessageLinked(LINK_SET, COMMAND_NOAUTH, sMsg, kID);
-            }
-            // added # as prefix for all subs aroubd BUT yourself
-            else if ((llGetSubString(sMsg, 0, 0) == "#") && (kID != g_kWearer))
-            {
-                sMsg = llGetSubString(sMsg, 1, -1);
-                llMessageLinked(LINK_SET, COMMAND_NOAUTH, sMsg, kID);
+                string cSign = llGetSubString(sMsg, 0, 0); // if first letter is..
+                if (cSign == "*")
+                {
+                    sMsg = llGetSubString(sMsg, 1, -1);
+                    llMessageLinked(LINK_SET, COMMAND_NOAUTH, sMsg, kID);
+                }
+                // added # as prefix for all subs aroubd BUT yourself
+                else if ((cSign == "#") && (kID != g_kWearer))
+                {
+                    sMsg = llGetSubString(sMsg, 1, -1);
+                    llMessageLinked(LINK_SET, COMMAND_NOAUTH, sMsg, kID);
+                }
+                // added @ prefix for all owned subs and yourself
+                else if (cSign == "@")
+                {
+                    // not removing sign, so Auth module will know to try change auth level
+                    llMessageLinked(LINK_SET, COMMAND_NOAUTH, sMsg, kID);
+                }
             }
         }
     }

--- a/lsl/OpenCollar - settings.lsl
+++ b/lsl/OpenCollar - settings.lsl
@@ -106,7 +106,7 @@ list DelSetting(list cache, string token) {
     return cache;
 }
 
-DumpCache() {
+DumpCache(key id) {
     string sOut = "Settings: \n";
 
 
@@ -118,14 +118,14 @@ DumpCache() {
         string sAdd = llList2String(settings_pairs, n) + "=" + llList2String(settings_pairs, n + 1) + "\n";
         if (llStringLength(sOut + sAdd) > 1024) {
             //spew and clear
-            llWhisper(0, "\n" + sOut);
+            Notify(id, "\n" + sOut, FALSE);
             sOut = sAdd;
         } else {
             //keep adding
             sOut += sAdd;
         }
     }
-    llWhisper(0, "\n" + sOut);
+    Notify(id, "\n" + sOut, FALSE);
 }
 
 SendValues() {
@@ -258,8 +258,8 @@ default {
             else if (str == "menu "+WIKI) {loadurl = TRUE; remenu = TRUE;}
             else if (num == COMMAND_OWNER || id == wearer)
             {
-                if (str == "cachedump") DumpCache();
-                else if (str == "menu "+DUMPCACHE) { DumpCache(); remenu = TRUE; }
+                if (str == "cachedump") DumpCache(id);
+                else if (str == "menu "+DUMPCACHE) { DumpCache(id); remenu = TRUE; }
                 else if (str == "reset" || str == "runaway") llResetScript();
                 else return;
             }

--- a/lsl/OpenCollar - settings.lsl
+++ b/lsl/OpenCollar - settings.lsl
@@ -106,7 +106,7 @@ list DelSetting(list cache, string token) {
     return cache;
 }
 
-DumpCache(key id) {
+DumpCache() {
     string sOut = "Settings: \n";
 
 
@@ -118,14 +118,14 @@ DumpCache(key id) {
         string sAdd = llList2String(settings_pairs, n) + "=" + llList2String(settings_pairs, n + 1) + "\n";
         if (llStringLength(sOut + sAdd) > 1024) {
             //spew and clear
-            Notify(id, "\n" + sOut, FALSE);
+            llWhisper(0, "\n" + sOut);
             sOut = sAdd;
         } else {
             //keep adding
             sOut += sAdd;
         }
     }
-    Notify(id, "\n" + sOut, FALSE);
+    llWhisper(0, "\n" + sOut);
 }
 
 SendValues() {
@@ -258,8 +258,8 @@ default {
             else if (str == "menu "+WIKI) {loadurl = TRUE; remenu = TRUE;}
             else if (num == COMMAND_OWNER || id == wearer)
             {
-                if (str == "cachedump") DumpCache(id);
-                else if (str == "menu "+DUMPCACHE) { DumpCache(id); remenu = TRUE; }
+                if (str == "cachedump") DumpCache();
+                else if (str == "menu "+DUMPCACHE) { DumpCache(); remenu = TRUE; }
                 else if (str == "reset" || str == "runaway") llResetScript();
                 else return;
             }


### PR DESCRIPTION
Proposal:

As far as I know there are two prefixes possible to an OpenCollar.  As I am Summerclaw Resident, my collar will respond to myself or an owner if they use "sr" as a prefix (I know that can be changed) or "*".

I propose another "generic" type prefix, perhaps "@".  The semantics for this new prefix is:

"All collars of which I am either a wearer or an owner/secowner."

Examples of situations in which this might be useful are when in a place where collars set to Open Access may be present.  An owner can use "@grab" to grab their subs without grabbing everyone with open access as well.  Of course they could grab them one by one too, I know.

Another example might be where two subs, one owned, the other open access, have the same initials.  Voice commands can be problematic then.

Solution:  

"listener" module  checks if command starts with "@"  and passes it without removing "@" from command.
"Auth" module  check  if  first letter of  command is "@". If  true, it check if Auth level identified  either owner\secowner or  wearer. if that true, "@" is cut from  command string and normal  Auth workflow continues. If not,  handling stopped , preventing script from  relaying  command further.
